### PR TITLE
user can move crosshair after the shot taken

### DIFF
--- a/script/crosshair.js
+++ b/script/crosshair.js
@@ -74,7 +74,7 @@ Crosshair.prototype = function(){
 
             var shotxpos = parseInt(target.canvas.style.left,10);
 
-            self.tracking = false;
+            self.tracking = true;
 
             var originalTop = parseInt(target.canvas.style.top,10);
             target.canvas.style.top = originalTop+5 + "px";


### PR DESCRIPTION
Ok, if we can not add a stroke, we can add a rights to the user to move the crosshair after shot taken